### PR TITLE
Implement domain model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@
 
 # Embedded web-server pid file
 /.web-server-pid
+.phpunit.result.cache
+/.phpunit.cache
+composer.lock

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/src/Domain/DomainEvent.php
+++ b/src/Domain/DomainEvent.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JakubCiszak\Orchestrator\Domain;
+
+interface DomainEvent
+{
+}

--- a/src/Domain/NextStepStrategyInterface.php
+++ b/src/Domain/NextStepStrategyInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JakubCiszak\Orchestrator\Domain;
+
+interface NextStepStrategyInterface
+{
+    public function decide(DomainEvent $event, ProcessState $state): ?string;
+}

--- a/src/Domain/ProcessState.php
+++ b/src/Domain/ProcessState.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JakubCiszak\Orchestrator\Domain;
+
+final class ProcessState
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        private readonly string $processId,
+        private string $currentStepId,
+        private array $metadata = [],
+    ) {
+    }
+
+    public function getProcessId(): string
+    {
+        return $this->processId;
+    }
+
+    public function getCurrentStepId(): string
+    {
+        return $this->currentStepId;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getMetadata(): array
+    {
+        return $this->metadata;
+    }
+
+    public function withCurrentStepId(string $currentStepId): self
+    {
+        $clone = clone $this;
+        $clone->currentStepId = $currentStepId;
+
+        return $clone;
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function withMetadata(array $metadata): self
+    {
+        $clone = clone $this;
+        $clone->metadata = $metadata;
+
+        return $clone;
+    }
+}

--- a/src/Domain/Step.php
+++ b/src/Domain/Step.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JakubCiszak\Orchestrator\Domain;
+
+final readonly class Step
+{
+    public function __construct(
+        private string $id,
+        private string $commandFqcn,
+        private string $expectedEventFqcn,
+        private NextStepStrategyInterface $nextStepStrategy,
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getCommandFqcn(): string
+    {
+        return $this->commandFqcn;
+    }
+
+    public function getExpectedEventFqcn(): string
+    {
+        return $this->expectedEventFqcn;
+    }
+
+    public function next(DomainEvent $event, ProcessState $state): ?string
+    {
+        return $this->nextStepStrategy->decide($event, $state);
+    }
+}

--- a/tests/Domain/StepTest.php
+++ b/tests/Domain/StepTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JakubCiszak\Orchestrator\Tests\Domain;
+
+use JakubCiszak\Orchestrator\Domain\{DomainEvent, NextStepStrategyInterface, ProcessState, Step};
+use PHPUnit\Framework\TestCase;
+
+final class StepTest extends TestCase
+{
+    public function testNextDelegatesDecisionToStrategy(): void
+    {
+        $strategy = new class() implements NextStepStrategyInterface {
+            public function decide(DomainEvent $event, ProcessState $state): ?string
+            {
+                return 'next_step';
+            }
+        };
+
+        $step = new Step('step1', 'SomeCommand', 'SomeEvent', $strategy);
+
+        $event = new class() implements DomainEvent {};
+        $state = new ProcessState('proc1', 'step1');
+
+        $this->assertSame('next_step', $step->next($event, $state));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce the core domain classes for workflow orchestration
- configure PHPUnit for tests
- add a sample `StepTest`

## Testing
- `php composer.phar analyse`
- `php composer.phar test` *(shows deprecation notice)*

------
https://chatgpt.com/codex/tasks/task_e_684893decea48330a4298a1d86c8f738