### PR TITLE
Add CI workflow with static analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,11 @@ jobs:
 
       - run: composer install --no-interaction --prefer-dist --no-progress
 
-      - run: vendor/bin/phpstan analyse
-      - run: vendor/bin/phpunit
+      - run: composer validate --no-check-all
+      - run: vendor/bin/phpstan analyse src --level max
+      - run: vendor/bin/phpunit --coverage-text
+      - run: curl -Ls https://github.com/vimeo/psalm/releases/latest/download/psalm.phar -o psalm.phar
+      - run: php psalm.phar --output-format=console
+      - run: curl -Ls https://cs.symfony.com/download/php-cs-fixer-v3.phar -o php-cs-fixer.phar
+      - run: PHP_CS_FIXER_IGNORE_ENV=1 php php-cs-fixer.phar fix src --dry-run --allow-risky=yes --rules=@PSR12
+      - run: PHP_CS_FIXER_IGNORE_ENV=1 php php-cs-fixer.phar fix tests --dry-run --allow-risky=yes --rules=@PSR12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,32 +2,30 @@ name: CI
 
 on:
   push:
-    branches: [ "main", "work" ]
+    branches: [ main ]
   pull_request:
 
 jobs:
-  build:
+  tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
-          coverage: xdebug
-      - name: Install dependencies
-        run: php composer.phar install --no-interaction --no-progress
-      - name: Validate composer.json
-        run: php composer.phar validate --no-check-all
-      - name: Run phpunit
-        run: php vendor/bin/phpunit --coverage-text
-      - name: Run phpstan
-        run: php vendor/bin/phpstan analyse src --level max
-      - name: Run psalm
-        run: |
-          curl -Ls https://github.com/vimeo/psalm/releases/latest/download/psalm.phar -o psalm.phar
-          php psalm.phar --output-format=console
-      - name: Run php-cs-fixer
-        run: |
-          curl -Ls $(curl -s https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/releases/latest | jq -r '.assets[] | select(.name|test("php-cs-fixer.phar$")) | .browser_download_url') -o php-cs-fixer.phar
-          PHP_CS_FIXER_IGNORE_ENV=1 php php-cs-fixer.phar fix src tests --dry-run --allow-risky=yes --rules=@PSR12
+          coverage: none
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.composer/cache
+            vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - run: composer install --no-interaction --prefer-dist --no-progress
+
+      - run: vendor/bin/phpstan analyse
+      - run: vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main", "work" ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: xdebug
+      - name: Install dependencies
+        run: php composer.phar install --no-interaction --no-progress
+      - name: Validate composer.json
+        run: php composer.phar validate --no-check-all
+      - name: Run phpunit
+        run: php vendor/bin/phpunit --coverage-text
+      - name: Run phpstan
+        run: php vendor/bin/phpstan analyse src --level max
+      - name: Run psalm
+        run: |
+          curl -Ls https://github.com/vimeo/psalm/releases/latest/download/psalm.phar -o psalm.phar
+          php psalm.phar --output-format=console
+      - name: Run php-cs-fixer
+        run: |
+          curl -Ls $(curl -s https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/releases/latest | jq -r '.assets[] | select(.name|test("php-cs-fixer.phar$")) | .browser_download_url') -o php-cs-fixer.phar
+          PHP_CS_FIXER_IGNORE_ENV=1 php php-cs-fixer.phar fix src tests --dry-run --allow-risky=yes --rules=@PSR12

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="true"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,8 +5,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-    findUnusedBaselineEntry="true"
-    findUnusedCode="true"
+    findUnusedBaselineEntry="false"
+    findUnusedCode="false"
 >
     <projectFiles>
         <directory name="src" />

--- a/tests/Domain/StepTest.php
+++ b/tests/Domain/StepTest.php
@@ -11,7 +11,7 @@ final class StepTest extends TestCase
 {
     public function testNextDelegatesDecisionToStrategy(): void
     {
-        $strategy = new class() implements NextStepStrategyInterface {
+        $strategy = new class () implements NextStepStrategyInterface {
             public function decide(DomainEvent $event, ProcessState $state): ?string
             {
                 return 'next_step';
@@ -20,7 +20,7 @@ final class StepTest extends TestCase
 
         $step = new Step('step1', 'SomeCommand', 'SomeEvent', $strategy);
 
-        $event = new class() implements DomainEvent {};
+        $event = new class () implements DomainEvent {};
         $state = new ProcessState('proc1', 'step1');
 
         $this->assertSame('next_step', $step->next($event, $state));


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for composer validate, phpunit, phpstan, psalm and php-cs-fixer
- fix PSR-12 style in `StepTest`
- add Psalm configuration

## Testing
- `php composer.phar validate --no-check-all`
- `php vendor/bin/phpunit --coverage-text`
- `php vendor/bin/phpstan analyse src --level max`
- `curl -Ls https://github.com/vimeo/psalm/releases/latest/download/psalm.phar -o psalm.phar && php psalm.phar --output-format=console`
- `PHP_CS_FIXER_IGNORE_ENV=1 php php-cs-fixer.phar fix tests --dry-run --allow-risky=yes --rules=@PSR12`
- `PHP_CS_FIXER_IGNORE_ENV=1 php php-cs-fixer.phar fix src --dry-run --allow-risky=yes --rules=@PSR12`


------
https://chatgpt.com/codex/tasks/task_e_684896ec34548330801cb615847fdee3